### PR TITLE
Added push_hash to the body sent to the push Adapter

### DIFF
--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -81,9 +81,9 @@ export class PushController extends AdaptableController {
         });
       }
     }
-    let pushStatus = pushStatusHandler(config);
+    let pushStatus = pushStatusHandler(body, config);
     return Promise.resolve().then(() => {
-      return pushStatus.setInitial(body, where);
+      return pushStatus.setInitial(where);
     }).then(() => {
       onPushStatusSaved(pushStatus.objectId);
       return badgeUpdate();
@@ -105,6 +105,10 @@ export class PushController extends AdaptableController {
   }
 
   sendToAdapter(body, installations, pushStatus, config) {
+    if(body.data) {
+      body.data["push_hash"] = pushStatus.pushHash;
+    }
+    
     if (body.data && body.data.badge && typeof body.data.badge == 'string' && body.data.badge.toLowerCase() == "increment") {
       // Collect the badges to reduce the # of calls
       let badgeInstallationsMap = installations.reduce((map, installation) => {

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -94,24 +94,27 @@ export function jobStatusHandler(config) {
   });
 }
 
-export function pushStatusHandler(config) {
+export function pushStatusHandler(body, config) {
 
   let pushStatus;
   let objectId = newObjectId();
   let database = config.database;
   let handler = statusHandler(PUSH_STATUS_COLLECTION, database);
+
+  let data =  body.data || {};
+  let pushHash;
+  if (typeof data.alert === 'string') {
+    pushHash = md5Hash(data.alert);
+  } else if (typeof data.alert === 'object') {
+    pushHash = md5Hash(JSON.stringify(data.alert));
+  } else {
+    pushHash = 'd41d8cd98f00b204e9800998ecf8427e';
+  }
+
   let setInitial = function(body = {}, where, options = {source: 'rest'}) {
     let now = new Date();
-    let data =  body.data || {};
+    
     let payloadString = JSON.stringify(data);
-    let pushHash;
-    if (typeof data.alert === 'string') {
-      pushHash = md5Hash(data.alert);
-    } else if (typeof data.alert === 'object') {
-      pushHash = md5Hash(JSON.stringify(data.alert));
-    } else {
-      pushHash = 'd41d8cd98f00b204e9800998ecf8427e';
-    }
     let object = {
       objectId,
       createdAt: now,
@@ -123,6 +126,7 @@ export function pushStatusHandler(config) {
       expiry: body.expiration_time,
       status: "pending",
       numSent: 0,
+      numOpened: 0,
       pushHash,
       // lockdown!
       ACL: {}
@@ -189,6 +193,7 @@ export function pushStatusHandler(config) {
   return Object.freeze({
     objectId,
     setInitial,
+    pushHash,
     setRunning,
     complete,
     fail


### PR DESCRIPTION
In order to track which push notifications is being triggered by the push open event, we need to send the push_hash to the adapter
